### PR TITLE
Add link badge to Replicate demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Carve/tracer_b7Cog model
 
+[![Try a demo on Replicate](https://replicate.com/lucataco/remove-bg/badge)](https://replicate.com/lucataco/remove-bg)
+
 This is an implementation of the [Carve/tracer_b7](https://huggingface.co/Carve/tracer_b7) as a Cog model. [Cog packages machine learning models as standard containers.](https://github.com/replicate/cog)
 
 First, download the pre-trained weights:


### PR DESCRIPTION
This PR adds a badge with a link to your model on Replicate, making it easier for users to try it out. 

Feel free to close if you don't want this, but many model creators have found it helpful.